### PR TITLE
Remove unwanted Bugs CONNECT tags from artist name

### DIFF
--- a/Bugs#Common_AlbumPage.inc
+++ b/Bugs#Common_AlbumPage.inc
@@ -1,6 +1,6 @@
 #
 # * Mp3tag web source for Bugs / Common script for parsing album page
-# v0.4.10 / 200903
+# v0.4.11 / 210627
 # 
 # * Installation
 # - just copy this script to:
@@ -88,8 +88,9 @@ do
     RegexpReplace "(\w{2,})\(" "$1 ("
     # NOTE require 2+ chars. to avoid 'f(x)' -> 'f (x)'
     RegexpReplace "\" >" "\">" 1
-    SayUntilML "</a>"
+    SayRest
 
+    FindLine "</a>"
     MoveLine +2
     Unspace
 while "<a href=\"https://music.bugs.co.kr/"


### PR DESCRIPTION
Some artist have a Bugs CONNECT tag next to their name.
(e.g. ```https://music.bugs.co.kr/album/4045861```)

It makes unwanted text included in artist tag.

This commit fix this problem.

e.g.
```
Masked Wolf, 루피 (Loopy)
                                                        <span class="badgeConnect connect1515">CONNECT 아티스트</span>, 오왼 (Owen)
                                                        <span class="badgeConnect connect1515">CONNECT 아티스트</span>, 블루 (BLOO)
                                                        <span class="badgeConnect connect1515">CONNECT 아티스트</span>
```

=> ```Masked Wolf, 루피 (Loopy), 오왼 (Owen), 블루 (BLOO)```