### PR TITLE
Fix track variable case in album parser

### DIFF
--- a/Bugs#Common_AlbumPage.inc
+++ b/Bugs#Common_AlbumPage.inc
@@ -244,7 +244,7 @@ Do
   # track number
   FindLine "<p class=\"trackIndex\">"
   MoveLine +1
-  OutputTo "tTrack"
+  OutputTo "ttrack"
   FindInLine "<em>"
   SayUntil "</em>"
   Say "|"


### PR DESCRIPTION
## Summary
- ensure track number variable matches existing case

## Testing
- `grep -n "ttrack" Bugs#Common_AlbumPage.inc`


------
https://chatgpt.com/codex/tasks/task_e_684d35bc2224832680abc5f8998cce79